### PR TITLE
Add default for CONDA_BUILD_CROSS_COMPILATION

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,7 +8,7 @@ sed -i.bak '1 s|^.*$|#!/usr/bin/env perl|g' $SRC_DIR/tests/t*.pl
 
 ./configure --prefix=${PREFIX}
 make -j${CPU_COUNT}
-if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]]; then
+if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" ]]; then
 make check
 fi
 make install


### PR DESCRIPTION
Builds fail because of unbounded variable. This hopefully solves the issue in the same way as https://github.com/conda-forge/libexif-feedstock/pull/1/commits/9c4ab47f286b3d8e3d9de492bc857bb9424b320d by @isuruf